### PR TITLE
Benhmarks.html: Load D3.js from network if local copy doesn't exist.

### DIFF
--- a/com.eclipsesource.json.performancetest/src/main/resources/charts/Benchmarks.html
+++ b/com.eclipsesource.json.performancetest/src/main/resources/charts/Benchmarks.html
@@ -16,6 +16,15 @@
   </div>
 
   <script src="d3.v3.min.js" charset="utf-8"></script>
+  <script>
+    var upstream_url = "http://d3js.org/d3.v3.min.js"
+    if( typeof d3 === 'undefined' ) {
+      document.write( '<p>Couldn\'t find "d3.v3.min.js" locally.')
+      document.write( '  Loading from "'+upstream_url+'", which is slightly slower.<'+'/p>')
+      document.write( '<script src="http://d3js.org/d3.v3.min.js" charset="utf-8"><'+'/script>' );
+    }
+  </script>
+
   <script src="benchmarks.js" charset="utf-8"></script>
   <script>
     window.onload = function() {


### PR DESCRIPTION
This is sort of messy, but so convenient.

Some alternatives:

- If the local copy of d3 doesn't load, just document.write(error_message) instead of loading the network copy.
- Add d3.js to the repo.