### PR TITLE
Implemented merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ jsonArray.set( 1, 24 ); // access element by index
 
 jsonObject.remove( "age" );
 jsonArray.remove( 1 );
+
+jsonObject.merge(otherObject); // merges both objects and overwrites with passed value
 ```
 
 ### Write JSON to a Writer or a String

--- a/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonObject.java
+++ b/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonObject.java
@@ -522,6 +522,24 @@ public class JsonObject extends JsonValue implements Iterable<Member> {
   }
 
   /**
+   * Merges this `object` with value of object. If both contain two keys with same names, the value
+   * from `object` will be chosen.
+   *
+   * @param object
+   *          the object from which to merge from
+   * @return the object itself, to enable method chaining
+   */
+  public JsonObject merge(JsonObject object) {
+    if (object == null) {
+      throw new NullPointerException("object is null");
+    }
+    for (Member member : object) {
+      this.set(member.name, member.value);
+    }
+    return this;
+  }
+
+  /**
    * Returns the value of the member with the specified name in this object. If this object contains
    * multiple members with the given name, this method will return the last one.
    *


### PR DESCRIPTION
I implemented merging as suggested by #23.

When one `jsonObject`'s merge method is called, it will use the passed `jsonObject`'s values and either copy them into the first one or overwrite them.

I hope this behavior was intended.