### PR TITLE
Constructor should be programmatically blocked.

### DIFF
--- a/com.eclipsesource.json/src/main/java/com/eclipsesource/json/Json.java
+++ b/com.eclipsesource.json/src/main/java/com/eclipsesource/json/Json.java
@@ -53,8 +53,8 @@ import java.io.Reader;
  */
 public final class Json {
 
-  private Json() {
-    // not meant to be instantiated
+  private Json() { // not meant to be instantiated
+    throw new AssertionError();
   }
 
   /**


### PR DESCRIPTION
From Eff. Java 2nd Ed.
  The AssertionError isn't strictly required, but it provides insurance
  in case the constructor is accidentally invoked from within the class.
  It guarantees that the class will never be instantiated under any
  circumstances.

At least to me, this makes your intentions even clearer than a comment.

Did not erase the comment, I think it should be kept.