### PR TITLE
Fix potentially null static fields

### DIFF
--- a/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonValue.java
+++ b/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonValue.java
@@ -68,21 +68,21 @@ public abstract class JsonValue implements Serializable {
    * @deprecated Use <code>Json.TRUE</code> instead
    */
   @Deprecated
-  public static final JsonValue TRUE = Json.TRUE;
+  public static final JsonValue TRUE = new JsonLiteral("true");
 
   /**
    * Represents the JSON literal <code>false</code>.
    * @deprecated Use <code>Json.FALSE</code> instead
    */
   @Deprecated
-  public static final JsonValue FALSE = Json.FALSE;
+  public static final JsonValue FALSE = new JsonLiteral("false");
 
   /**
    * Represents the JSON literal <code>null</code>.
    * @deprecated Use <code>Json.NULL</code> instead
    */
   @Deprecated
-  public static final JsonValue NULL = Json.NULL;
+  public static final JsonValue NULL = new JsonLiteral("null");
 
   JsonValue() {
     // prevent subclasses outside of this package

--- a/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonValue_Test.java
+++ b/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonValue_Test.java
@@ -41,9 +41,9 @@ public class JsonValue_Test {
   @Test
   @SuppressWarnings("deprecation")
   public void testConstantsAreLiterals() {
-    assertSame(Json.NULL, JsonValue.NULL);
-    assertSame(Json.TRUE, JsonValue.TRUE);
-    assertSame(Json.FALSE, JsonValue.FALSE);
+    assertEquals(Json.NULL, JsonValue.NULL);
+    assertEquals(Json.TRUE, JsonValue.TRUE);
+    assertEquals(Json.FALSE, JsonValue.FALSE);
   }
 
   @Test


### PR DESCRIPTION
Hi,

In Fedora, we've got an rpm package for this, and I'm one of the
maintainers for that.

We've noticed that there's a test that fails intermittently, and another
contributor [pointed out](https://lists.fedoraproject.org/pipermail/java-devel/2015-September/005688.html) that depending on which of the classes gets initialized first.

The change that I'm proposing here allows us to build this consistently,
so I hope you'll consider it.

Thanks,
Gerard.