### PR TITLE
Adding tests for JsonObject with repeated properties names

### DIFF
--- a/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonObject_Test.java
+++ b/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonObject_Test.java
@@ -154,6 +154,22 @@ public class JsonObject_Test {
   }
 
   @Test
+  public void allowsMultipleEntriesWithRepeatedNames() {
+    object.add("a", true);
+    object.add("a", "value");
+
+    assertEquals(2, object.size());
+  }
+
+  @Test
+  public void getsLastEntryWithRepeatedNames() {
+    object.add("a", true);
+    object.add("a", "value");
+
+    assertEquals("value", object.getString("a", "missing"));
+  }
+
+  @Test
   public void names_emptyAfterCreation() {
     assertTrue(object.names().isEmpty());
   }

--- a/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonObject_Test.java
+++ b/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonObject_Test.java
@@ -154,7 +154,7 @@ public class JsonObject_Test {
   }
 
   @Test
-  public void allowsMultipleEntriesWithRepeatedNames() {
+  public void keyRepetition_allowsMultipleEntries() {
     object.add("a", true);
     object.add("a", "value");
 
@@ -162,11 +162,26 @@ public class JsonObject_Test {
   }
 
   @Test
-  public void getsLastEntryWithRepeatedNames() {
+  public void keyRepetition_getsLastEntry() {
     object.add("a", true);
     object.add("a", "value");
 
     assertEquals("value", object.getString("a", "missing"));
+  }
+
+  @Test
+  public void keyRepetition_equalityConsidersRepetitions() {
+    object.add("a", true);
+    object.add("a", "value");
+
+    JsonObject onlyFirstProperty = new JsonObject();
+    onlyFirstProperty.add("a", true);
+    assertNotEquals(onlyFirstProperty, object);
+
+    JsonObject bothProperties = new JsonObject();
+    bothProperties.add("a", true);
+    bothProperties.add("a", "value");
+    assertEquals(bothProperties, object);
   }
 
   @Test


### PR DESCRIPTION
Since allowing properties with repeated names is a deliberate feature, I've added a couple of tests to document that.