### PR TITLE
Remove deprecated API

### DIFF
--- a/com.eclipsesource.json.performancetest/src/main/java/com/eclipsesource/json/performancetest/caliper/CaliperRunner.java
+++ b/com.eclipsesource.json.performancetest/src/main/java/com/eclipsesource/json/performancetest/caliper/CaliperRunner.java
@@ -38,6 +38,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 import com.google.caliper.Arguments;
 import com.google.caliper.Benchmark;
@@ -95,7 +96,7 @@ public class CaliperRunner {
   }
 
   private void createJsonFile() throws IOException {
-    JsonObject caliperJson = JsonObject.readFrom(readFromFile(resultsFile));
+    JsonObject caliperJson = Json.parse(readFromFile(resultsFile)).asObject();
     String resultsJson = new CaliperResultsPreprocessor(caliperJson).getResults().toString();
     writeToFile(resultsJson, resultsFile);
   }

--- a/com.eclipsesource.json.performancetest/src/main/java/com/eclipsesource/json/performancetest/jsonrunners/MinimalJsonRunner.java
+++ b/com.eclipsesource.json.performancetest/src/main/java/com/eclipsesource/json/performancetest/jsonrunners/MinimalJsonRunner.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 
+import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonValue;
 
 
@@ -32,12 +33,12 @@ public class MinimalJsonRunner extends JsonRunner {
 
   @Override
   public Object readFromString(String string) throws IOException {
-    return JsonValue.readFrom(string);
+    return Json.parse(string);
   }
 
   @Override
   public Object readFromReader(Reader reader) throws IOException {
-    return JsonValue.readFrom(reader);
+    return Json.parse(reader);
   }
 
   @Override

--- a/com.eclipsesource.json.performancetest/src/test/java/com/eclipsesource/json/performancetest/caliper/CaliperResultsPreprocessor_Test.java
+++ b/com.eclipsesource.json.performancetest/src/test/java/com/eclipsesource/json/performancetest/caliper/CaliperResultsPreprocessor_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 EclipseSource.
+ * Copyright (c) 2013, 2017 EclipseSource.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,13 +22,16 @@
 package com.eclipsesource.json.performancetest.caliper;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.performancetest.resources.Resources;
 
@@ -39,7 +42,7 @@ public class CaliperResultsPreprocessor_Test {
 
   @BeforeClass
   public static void loadCaliperJson() throws IOException {
-    caliperJson = JsonObject.readFrom(Resources.readResource("input/caliper.json"));
+    caliperJson = Json.parse(Resources.readResource("input/caliper.json")).asObject();
   }
 
   @Test

--- a/com.eclipsesource.json.performancetest/src/test/java/com/eclipsesource/json/performancetest/jsonrunners/JsonRunner_Test.java
+++ b/com.eclipsesource.json.performancetest/src/test/java/com/eclipsesource/json/performancetest/jsonrunners/JsonRunner_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 EclipseSource and others.
+ * Copyright (c) 2013, 2017 EclipseSource and others.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,9 @@ package com.eclipsesource.json.performancetest.jsonrunners;
 
 import static com.eclipsesource.json.performancetest.resources.Resources.readResource;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -41,6 +43,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
+import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
@@ -73,11 +76,11 @@ public class JsonRunner_Test {
     runner = JsonRunnerFactory.findByName(name);
     json = readResource("input/test.json");
     jsonBytes = json.getBytes(JsonRunner.UTF8);
-    minimalJsonModel = JsonValue.readFrom(json);
+    minimalJsonModel = Json.parse(json);
   }
 
   private void assertJsonCorrect(String s) {
-    assertTrue(equalsIgnoreOrder(minimalJsonModel, JsonValue.readFrom(s)));
+    assertTrue(equalsIgnoreOrder(minimalJsonModel, Json.parse(s)));
   }
 
   private void assertJsonCorrect(byte[] ba) {

--- a/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonArray.java
+++ b/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonArray.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 EclipseSource.
+ * Copyright (c) 2013, 2017 EclipseSource.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,6 @@
 package com.eclipsesource.json;
 
 import java.io.IOException;
-import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -90,47 +89,6 @@ public class JsonArray extends JsonValue implements Iterable<JsonValue> {
     } else {
       values = new ArrayList<JsonValue>(array.values);
     }
-  }
-
-  /**
-   * Reads a JSON array from the given reader.
-   * <p>
-   * Characters are read in chunks and buffered internally, therefore wrapping an existing reader in
-   * an additional <code>BufferedReader</code> does <strong>not</strong> improve reading
-   * performance.
-   * </p>
-   *
-   * @param reader
-   *          the reader to read the JSON array from
-   * @return the JSON array that has been read
-   * @throws IOException
-   *           if an I/O error occurs in the reader
-   * @throws ParseException
-   *           if the input is not valid JSON
-   * @throws UnsupportedOperationException
-   *           if the input does not contain a JSON array
-   * @deprecated Use {@link Json#parse(Reader)}{@link JsonValue#asArray() .asArray()} instead
-   */
-  @Deprecated
-  public static JsonArray readFrom(Reader reader) throws IOException {
-    return JsonValue.readFrom(reader).asArray();
-  }
-
-  /**
-   * Reads a JSON array from the given string.
-   *
-   * @param string
-   *          the string that contains the JSON array
-   * @return the JSON array that has been read
-   * @throws ParseException
-   *           if the input is not valid JSON
-   * @throws UnsupportedOperationException
-   *           if the input does not contain a JSON array
-   * @deprecated Use {@link Json#parse(String)}{@link JsonValue#asArray() .asArray()} instead
-   */
-  @Deprecated
-  public static JsonArray readFrom(String string) {
-    return JsonValue.readFrom(string).asArray();
   }
 
   /**

--- a/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonObject.java
+++ b/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonObject.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 EclipseSource.
+ * Copyright (c) 2013, 2017 EclipseSource.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,6 @@ package com.eclipsesource.json;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -108,47 +107,6 @@ public class JsonObject extends JsonValue implements Iterable<Member> {
     }
     table = new HashIndexTable();
     updateHashIndex();
-  }
-
-  /**
-   * Reads a JSON object from the given reader.
-   * <p>
-   * Characters are read in chunks and buffered internally, therefore wrapping an existing reader in
-   * an additional <code>BufferedReader</code> does <strong>not</strong> improve reading
-   * performance.
-   * </p>
-   *
-   * @param reader
-   *          the reader to read the JSON object from
-   * @return the JSON object that has been read
-   * @throws IOException
-   *           if an I/O error occurs in the reader
-   * @throws ParseException
-   *           if the input is not valid JSON
-   * @throws UnsupportedOperationException
-   *           if the input does not contain a JSON object
-   * @deprecated Use {@link Json#parse(Reader)}{@link JsonValue#asObject() .asObject()} instead
-   */
-  @Deprecated
-  public static JsonObject readFrom(Reader reader) throws IOException {
-    return JsonValue.readFrom(reader).asObject();
-  }
-
-  /**
-   * Reads a JSON object from the given string.
-   *
-   * @param string
-   *          the string that contains the JSON object
-   * @return the JSON object that has been read
-   * @throws ParseException
-   *           if the input is not valid JSON
-   * @throws UnsupportedOperationException
-   *           if the input does not contain a JSON object
-   * @deprecated Use {@link Json#parse(String)}{@link JsonValue#asObject() .asObject()} instead
-   */
-  @Deprecated
-  public static JsonObject readFrom(String string) {
-    return JsonValue.readFrom(string).asObject();
   }
 
   /**

--- a/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonValue.java
+++ b/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonValue.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2016 EclipseSource.
+ * Copyright (c) 2013, 2017 EclipseSource.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,6 @@
 package com.eclipsesource.json;
 
 import java.io.IOException;
-import java.io.Reader;
 import java.io.Serializable;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -33,10 +32,6 @@ import java.io.Writer;
  * a <strong>number</strong>, a <strong>string</strong>, or one of the literals
  * <strong>true</strong>, <strong>false</strong>, and <strong>null</strong>.
  * <p>
- * The literals <strong>true</strong>, <strong>false</strong>, and <strong>null</strong> are
- * represented by the constants {@link #TRUE}, {@link #FALSE}, and {@link #NULL}.
- * </p>
- * <p>
  * JSON <strong>objects</strong> and <strong>arrays</strong> are represented by the subtypes
  * {@link JsonObject} and {@link JsonArray}. Instances of these types can be created using the
  * public constructors of these classes.
@@ -44,7 +39,7 @@ import java.io.Writer;
  * <p>
  * Instances that represent JSON <strong>numbers</strong>, <strong>strings</strong> and
  * <strong>boolean</strong> values can be created using the static factory methods
- * {@link #valueOf(String)}, {@link #valueOf(long)}, {@link #valueOf(double)}, etc.
+ * {@link Json#value(String)}, {@link Json#value(long)}, {@link Json#value(double)}, etc.
  * </p>
  * <p>
  * In order to find out whether an instance of this class is of a certain type, the methods
@@ -63,144 +58,8 @@ import java.io.Writer;
 @SuppressWarnings("serial") // use default serial UID
 public abstract class JsonValue implements Serializable {
 
-  /**
-   * Represents the JSON literal <code>true</code>.
-   * @deprecated Use <code>Json.TRUE</code> instead
-   */
-  @Deprecated
-  public static final JsonValue TRUE = new JsonLiteral("true");
-
-  /**
-   * Represents the JSON literal <code>false</code>.
-   * @deprecated Use <code>Json.FALSE</code> instead
-   */
-  @Deprecated
-  public static final JsonValue FALSE = new JsonLiteral("false");
-
-  /**
-   * Represents the JSON literal <code>null</code>.
-   * @deprecated Use <code>Json.NULL</code> instead
-   */
-  @Deprecated
-  public static final JsonValue NULL = new JsonLiteral("null");
-
   JsonValue() {
     // prevent subclasses outside of this package
-  }
-
-  /**
-   * Reads a JSON value from the given reader.
-   * <p>
-   * Characters are read in chunks and buffered internally, therefore wrapping an existing reader in
-   * an additional <code>BufferedReader</code> does <strong>not</strong> improve reading
-   * performance.
-   * </p>
-   *
-   * @param reader
-   *          the reader to read the JSON value from
-   * @return the JSON value that has been read
-   * @throws IOException
-   *           if an I/O error occurs in the reader
-   * @throws ParseException
-   *           if the input is not valid JSON
-   * @deprecated Use {@link Json#parse(Reader)} instead
-   */
-  @Deprecated
-  public static JsonValue readFrom(Reader reader) throws IOException {
-    return Json.parse(reader);
-  }
-
-  /**
-   * Reads a JSON value from the given string.
-   *
-   * @param text
-   *          the string that contains the JSON value
-   * @return the JSON value that has been read
-   * @throws ParseException
-   *           if the input is not valid JSON
-   * @deprecated Use {@link Json#parse(String)} instead
-   */
-  @Deprecated
-  public static JsonValue readFrom(String text) {
-    return Json.parse(text);
-  }
-
-  /**
-   * Returns a JsonValue instance that represents the given <code>int</code> value.
-   *
-   * @param value
-   *          the value to get a JSON representation for
-   * @return a JSON value that represents the given value
-   * @deprecated Use <code>Json.value()</code> instead
-   */
-  @Deprecated
-  public static JsonValue valueOf(int value) {
-    return Json.value(value);
-  }
-
-  /**
-   * Returns a JsonValue instance that represents the given <code>long</code> value.
-   *
-   * @param value
-   *          the value to get a JSON representation for
-   * @return a JSON value that represents the given value
-   * @deprecated Use <code>Json.value()</code> instead
-   */
-  @Deprecated
-  public static JsonValue valueOf(long value) {
-    return Json.value(value);
-  }
-
-  /**
-   * Returns a JsonValue instance that represents the given <code>float</code> value.
-   *
-   * @param value
-   *          the value to get a JSON representation for
-   * @return a JSON value that represents the given value
-   * @deprecated Use <code>Json.value()</code> instead
-   */
-  @Deprecated
-  public static JsonValue valueOf(float value) {
-    return Json.value(value);
-  }
-
-  /**
-   * Returns a JsonValue instance that represents the given <code>double</code> value.
-   *
-   * @param value
-   *          the value to get a JSON representation for
-   * @return a JSON value that represents the given value
-   * @deprecated Use <code>Json.value()</code> instead
-   */
-  @Deprecated
-  public static JsonValue valueOf(double value) {
-    return Json.value(value);
-  }
-
-  /**
-   * Returns a JsonValue instance that represents the given string.
-   *
-   * @param string
-   *          the string to get a JSON representation for
-   * @return a JSON value that represents the given string
-   * @deprecated Use <code>Json.value()</code> instead
-   */
-  @Deprecated
-  public static JsonValue valueOf(String string) {
-    return Json.value(string);
-  }
-
-  /**
-   * Returns a JsonValue instance that represents the given <code>boolean</code> value.
-   *
-   * @param value
-   *          the value to get a JSON representation for
-   * @return a JSON value that represents the given value
-   * @deprecated Use <code>Json.value()</code> instead
-   */
-  @Deprecated
-  public static JsonValue valueOf(boolean value) {
-    return Json.value(value);
   }
 
   /**
@@ -439,7 +298,7 @@ public abstract class JsonValue implements Serializable {
 
   /**
    * Returns the JSON string for this value in its minimal form, without any additional whitespace.
-   * The result is guaranteed to be a valid input for the method {@link #readFrom(String)} and to
+   * The result is guaranteed to be a valid input for the method {@link Json#parse(String)} and to
    * create a value that is <em>equal</em> to this object.
    *
    * @return a JSON string that represents this value

--- a/com.eclipsesource.json/src/main/java/com/eclipsesource/json/ParseException.java
+++ b/com.eclipsesource.json/src/main/java/com/eclipsesource/json/ParseException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2016 EclipseSource.
+ * Copyright (c) 2013, 2017 EclipseSource.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,41 +41,6 @@ public class ParseException extends RuntimeException {
    */
   public Location getLocation() {
     return location;
-  }
-
-  /**
-   * Returns the absolute character index at which the error occurred. The offset of the first
-   * character of a document is 0.
-   *
-   * @return the character offset at which the error occurred, will be &gt;= 0
-   * @deprecated Use {@link #getLocation()} instead
-   */
-  @Deprecated
-  public int getOffset() {
-    return location.offset;
-  }
-
-  /**
-   * Returns the line number in which the error occurred. The number of the first line is 1.
-   *
-   * @return the line in which the error occurred, will be &gt;= 1
-   * @deprecated Use {@link #getLocation()} instead
-   */
-  @Deprecated
-  public int getLine() {
-    return location.line;
-  }
-
-  /**
-   * Returns the column number at which the error occurred, i.e. the number of the character in its
-   * line. The number of the first character of a line is 1.
-   *
-   * @return the column in which the error occurred, will be &gt;= 1
-   * @deprecated Use {@link #getLocation()} instead
-   */
-  @Deprecated
-  public int getColumn() {
-    return location.column;
   }
 
 }

--- a/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonArray_Test.java
+++ b/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonArray_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 EclipseSource.
+ * Copyright (c) 2013, 2017 EclipseSource.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,12 +23,14 @@ package com.eclipsesource.json;
 
 import static com.eclipsesource.json.TestUtil.assertException;
 import static com.eclipsesource.json.TestUtil.serializeAndDeserialize;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
-import java.io.StringReader;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
@@ -93,33 +95,6 @@ public class JsonArray_Test {
     JsonArray unmodifiableArray = JsonArray.unmodifiableArray(array);
 
     unmodifiableArray.add(23);
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void readFrom_reader() throws IOException {
-    assertEquals(new JsonArray(), JsonArray.readFrom(new StringReader("[]")));
-    assertEquals(new JsonArray().add("a").add(23),
-                 JsonArray.readFrom(new StringReader("[ \"a\", 23 ]")));
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void readFrom_string() {
-    assertEquals(new JsonArray(), JsonArray.readFrom("[]"));
-    assertEquals(new JsonArray().add("a").add(23), JsonArray.readFrom("[ \"a\", 23 ]"));
-  }
-
-  @Test(expected = ParseException.class)
-  @SuppressWarnings("deprecation")
-  public void readFrom_illegalJson() {
-    JsonArray.readFrom("This is not JSON");
-  }
-
-  @Test(expected = UnsupportedOperationException.class)
-  @SuppressWarnings("deprecation")
-  public void readFrom_wrongJsonType() {
-    JsonArray.readFrom("\"This is not a JSON object\"");
   }
 
   @Test

--- a/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonObject_Test.java
+++ b/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonObject_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 EclipseSource.
+ * Copyright (c) 2013, 2017 EclipseSource.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,12 +23,16 @@ package com.eclipsesource.json;
 
 import static com.eclipsesource.json.TestUtil.assertException;
 import static com.eclipsesource.json.TestUtil.serializeAndDeserialize;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
-import java.io.StringReader;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
@@ -100,33 +104,6 @@ public class JsonObject_Test {
     JsonObject unmodifiableObject = JsonObject.unmodifiableObject(object);
 
     unmodifiableObject.add("foo", 23);
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void readFrom_reader() throws IOException {
-    assertEquals(new JsonObject(), JsonObject.readFrom(new StringReader("{}")));
-    assertEquals(new JsonObject().add("a", 23),
-                 JsonObject.readFrom(new StringReader("{ \"a\": 23 }")));
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void readFrom_string() {
-    assertEquals(new JsonObject(), JsonObject.readFrom("{}"));
-    assertEquals(new JsonObject().add("a", 23), JsonObject.readFrom("{ \"a\": 23 }"));
-  }
-
-  @Test(expected = ParseException.class)
-  @SuppressWarnings("deprecation")
-  public void readFrom_illegalJson() {
-    JsonObject.readFrom("This is not JSON");
-  }
-
-  @Test(expected = UnsupportedOperationException.class)
-  @SuppressWarnings("deprecation")
-  public void readFrom_wrongJsonType() {
-    JsonObject.readFrom("\"This is not a JSON object\"");
   }
 
   @Test

--- a/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonValue_Test.java
+++ b/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonValue_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 EclipseSource.
+ * Copyright (c) 2013, 2017 EclipseSource.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,12 +22,13 @@
 package com.eclipsesource.json;
 
 import static com.eclipsesource.json.TestUtil.assertException;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 
@@ -37,78 +38,6 @@ import com.eclipsesource.json.TestUtil.RunnableEx;
 
 
 public class JsonValue_Test {
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void testConstantsAreLiterals() {
-    assertEquals(Json.NULL, JsonValue.NULL);
-    assertEquals(Json.TRUE, JsonValue.TRUE);
-    assertEquals(Json.FALSE, JsonValue.FALSE);
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void valueOf_int() {
-    assertEquals(Json.value(23), JsonValue.valueOf(23));
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void valueOf_long() {
-    assertEquals(Json.value(23l), JsonValue.valueOf(23l));
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void valueOf_float() {
-    assertEquals(Json.value(23.5f), JsonValue.valueOf(23.5f));
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void valueOf_double() {
-    assertEquals(Json.value(23.5d), JsonValue.valueOf(23.5d));
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void valueOf_boolean() {
-    assertSame(Json.value(true), JsonValue.valueOf(true));
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void valueOf_string() {
-    assertEquals(Json.value("foo"), JsonValue.valueOf("foo"));
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void readFrom_string() {
-    assertEquals(new JsonArray(), JsonValue.readFrom("[]"));
-    assertEquals(new JsonObject(), JsonValue.readFrom("{}"));
-    assertEquals(Json.value(23), JsonValue.readFrom("23"));
-    assertSame(Json.NULL, JsonValue.readFrom("null"));
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void readFrom_reader() throws IOException {
-    assertEquals(new JsonArray(), JsonValue.readFrom(new StringReader("[]")));
-    assertEquals(new JsonObject(), JsonValue.readFrom(new StringReader("{}")));
-    assertEquals(Json.value(23), JsonValue.readFrom(new StringReader("23")));
-    assertSame(Json.NULL, JsonValue.readFrom(new StringReader("null")));
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void readFrom_reader_doesNotCloseReader() throws IOException {
-    Reader reader = spy(new StringReader("{}"));
-
-    JsonValue.readFrom(reader);
-
-    verify(reader, never()).close();
-  }
 
   @Test
   public void writeTo() throws IOException {

--- a/com.eclipsesource.json/src/test/java/com/eclipsesource/json/ParseException_Test.java
+++ b/com.eclipsesource.json/src/test/java/com/eclipsesource/json/ParseException_Test.java
@@ -45,16 +45,6 @@ public class ParseException_Test {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
-  public void position() {
-    ParseException exception = new ParseException("Foo", location);
-
-    assertEquals(location.offset, exception.getOffset());
-    assertEquals(location.line, exception.getLine());
-    assertEquals(location.column, exception.getColumn());
-  }
-
-  @Test
   public void message() {
     ParseException exception = new ParseException("Foo", location);
 


### PR DESCRIPTION
As reported in #77, the reference from the static fields in `JsonValue`
to static fields in `Json` can lead to deadlocks during class
initialization.

Since this API has only been added for compatibility, the easiest fix
seems to be to remove the deprecated fields in `JsonValue`.

Use this opportunity to remove all deprecated API for 0.9.5.

This commit should fix #77.