### PR TITLE
Adds JsonObject#contains

### DIFF
--- a/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonObject.java
+++ b/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonObject.java
@@ -526,6 +526,19 @@ public class JsonObject extends JsonValue implements Iterable<Member> {
   }
 
   /**
+   * Checks if a specified member is present as a child of this object. This will not test if
+   * this object contains the literal <code>null</code>, {@link JsonValue#isNull()} should be used
+   * for this purpose.
+   *
+   * @param name
+   *          the name of the member to check for
+   * @return whether or not the member is present
+   */
+  public boolean contains(String name) {
+    return names.contains(name);
+  }
+
+  /**
    * Copies all members of the specified object into this object. When the specified object contains
    * members with names that also exist in this object, the existing values in this object will be
    * replaced by the corresponding values in the specified object.

--- a/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonObject_Test.java
+++ b/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonObject_Test.java
@@ -718,6 +718,27 @@ public class JsonObject_Test {
   }
 
   @Test
+  public void contains_findsAddedMembers(){
+    object.add("f", 15f);
+
+    assertTrue(object.contains("f"));
+  }
+
+  @Test
+  public void contains_doesNotFindAbsentMembers(){
+    assertFalse(object.contains("a"));
+  }
+
+  @Test
+  public void contains_doesNotFindDeletedMembers(){
+    object.add("a", "foo");
+
+    object.remove("a");
+
+    assertFalse(object.contains("a"));
+  }
+
+  @Test
   public void merge_failsWithNull() {
     assertException(NullPointerException.class, "object is null", new Runnable() {
       public void run() {


### PR DESCRIPTION
I was moving over to this API from Jackson, and couldn't find a method for checking the presence of a member of an object. I know that you can always check if a value is null, but I would love something more concise.