### PR TITLE
remove deprecated static fields to avoid deadlock

### DIFF
--- a/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonValue.java
+++ b/com.eclipsesource.json/src/main/java/com/eclipsesource/json/JsonValue.java
@@ -63,27 +63,6 @@ import java.io.Writer;
 @SuppressWarnings("serial") // use default serial UID
 public abstract class JsonValue implements Serializable {
 
-  /**
-   * Represents the JSON literal <code>true</code>.
-   * @deprecated Use <code>Json.TRUE</code> instead
-   */
-  @Deprecated
-  public static final JsonValue TRUE = new JsonLiteral("true");
-
-  /**
-   * Represents the JSON literal <code>false</code>.
-   * @deprecated Use <code>Json.FALSE</code> instead
-   */
-  @Deprecated
-  public static final JsonValue FALSE = new JsonLiteral("false");
-
-  /**
-   * Represents the JSON literal <code>null</code>.
-   * @deprecated Use <code>Json.NULL</code> instead
-   */
-  @Deprecated
-  public static final JsonValue NULL = new JsonLiteral("null");
-
   JsonValue() {
     // prevent subclasses outside of this package
   }

--- a/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonValue_Test.java
+++ b/com.eclipsesource.json/src/test/java/com/eclipsesource/json/JsonValue_Test.java
@@ -40,14 +40,6 @@ public class JsonValue_Test {
 
   @Test
   @SuppressWarnings("deprecation")
-  public void testConstantsAreLiterals() {
-    assertEquals(Json.NULL, JsonValue.NULL);
-    assertEquals(Json.TRUE, JsonValue.TRUE);
-    assertEquals(Json.FALSE, JsonValue.FALSE);
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
   public void valueOf_int() {
     assertEquals(Json.value(23), JsonValue.valueOf(23));
   }


### PR DESCRIPTION
I cannot understand why this wasn't done 2.5 years ago. Your popular project is used in many projects however is woefully unreliable due to this very fixable issue.